### PR TITLE
updated 'after_update: order_recap' for email 2 B sent only when order is paid

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,9 +1,14 @@
 class Order < ApplicationRecord
-  after_create :order_recap
+  after_update :order_recap
   
   belongs_to :user
 
+  private
+
   def order_recap
-    UserMailer.order_recap_email(self).deliver_now
+    unless self.pickup_code == "not_paid"
+      UserMailer.order_recap_email(self).deliver_now
+    end
   end
+
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -63,7 +63,7 @@ i=1
 end
 
 10.times do
-  Order.create(total_amount: Faker::Commerce.price, pickup_code:"-", user:User.find(rand(User.first.id..User.last.id)))
+  Order.create(total_amount: Faker::Commerce.price, pickup_code:"not_paid", user:User.find(rand(User.first.id..User.last.id)))
 end
 
 10.times do


### PR DESCRIPTION
the email is sent when the order's pickup_code is updated from "not_paid" to the actual pick_up code generated when the order is paid.